### PR TITLE
feat: Implement Polyphonic Aftertouch and On-Screen Wheels

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -230,6 +230,21 @@ class InteractiveKnobPainter extends CustomPainter {
 }
 ```
 
+#### Interactive Performance Controls
+
+*   **VirtualKeyboardWidget**: Provides an on-screen piano keyboard for note input.
+    *   Sends note on/off messages through the `AudioEngine`.
+    *   Supports **Polyphonic Aftertouch**, sending pressure data (0-127) for individual notes via `NativeAudioLib.sendPolyAftertouch(note, pressure)`.
+*   **PitchBendWheelWidget**: An on-screen virtual wheel to control MIDI pitch bend.
+    *   Drag to change pitch bend value (-1.0 to 1.0 UI range).
+    *   Automatically returns to center (0.0) upon release.
+    *   Sends 14-bit MIDI pitch bend messages (0-16383, center 8192) via `NativeAudioLib.sendPitchBend(value)`.
+*   **ModulationWheelWidget**: An on-screen virtual wheel to control MIDI CC messages, typically CC#1 (Modulation).
+    *   Drag to change CC value (0.0 to 1.0 UI range).
+    *   Stays in position upon release.
+    *   Configurable `ccNumber` property.
+    *   Sends 7-bit MIDI CC messages (controller number, value 0-127) via `NativeAudioLib.sendControlChange(cc, value)`.
+
 ## 🌐 Cloud Functions API
 
 ### generatePreset Function

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ While this marks a major milestone, Synther Professional is an ambitious project
 - **Performance Modes**: Normal, Performance, Minimal, Visualizer-only
 - **Holographic Aesthetics**: Translucency, parallax, neon glow, scanline effects
 - **Touch-First Design**: Optimized for mobile with haptic feedback
+- **Polyphonic Aftertouch**: Virtual keyboard supports per-note pressure sensitivity.
+- **On-Screen Pitch Bend Wheel**: Dedicated control for MIDI pitch bend with auto-return.
+- **On-Screen Modulation Wheel**: Dedicated, configurable control for MIDI CC messages (e.g., Mod Wheel CC#1).
 
 ### 🌌 HyperAV 4D Visualizer
 - **Real-Time 4D Geometry**: Hypercube, hypersphere, and complex polytope rendering

--- a/lib/core/ffi/native_audio_ffi.dart
+++ b/lib/core/ffi/native_audio_ffi.dart
@@ -53,7 +53,8 @@ typedef SendPolyAftertouchC = Void Function(Int32 noteNumber, Int32 pressure);
 
 // Pitch Bend & Mod Wheel FFI functions
 typedef SendPitchBendC = Void Function(Int32 value);
-typedef SendModWheelC = Void Function(Int32 value);
+typedef SendModWheelC = Void Function(Int32 value); // Specific to CC1 (Mod Wheel)
+typedef SendControlChangeC = Void Function(Int32 controller, Int32 value); // Generic CC
 
 
 // --- Typedefs for Dart functions ---
@@ -88,7 +89,8 @@ typedef SetXYPadAxisParameterDart = void Function(int parameterId);
 typedef SendPolyAftertouchDart = void Function(int noteNumber, int pressure);
 
 typedef SendPitchBendDart = void Function(int value);
-typedef SendModWheelDart = void Function(int value);
+typedef SendModWheelDart = void Function(int value); // Specific to CC1 (Mod Wheel)
+typedef SendControlChangeDart = void Function(int controller, int value); // Generic CC
 
 
 class NativeAudioLib {
@@ -143,8 +145,25 @@ class NativeAudioLib {
   late SendPolyAftertouchDart sendPolyAftertouch;
 
   // Pitch Bend & Mod Wheel
+
+  /// Sends a MIDI Pitch Bend message.
+  ///
+  /// The [bendValue] is a 14-bit integer (0-16383), where 8192 represents
+  /// no pitch change (center). 0 is maximum bend down, and 16383 is maximum
+  /// bend up.
   late SendPitchBendDart sendPitchBend;
-  late SendModWheelDart sendModWheel;
+
+  /// Sends a MIDI Mod Wheel message (Control Change #1).
+  /// This is a specific instance of a Control Change message.
+  ///
+  /// The [value] is a 7-bit integer (0-127).
+  late SendModWheelDart sendModWheel; // Specific to CC1
+
+  /// Sends a generic MIDI Control Change (CC) message.
+  ///
+  /// The [controller] number (0-127) identifies the CC parameter.
+  /// The [value] (0-127) is the value for that controller.
+  late SendControlChangeDart sendControlChange; // Generic CC
 
 
   NativeAudioLib._internal() {
@@ -276,6 +295,9 @@ class NativeAudioLib {
 
     // Pitch Bend & Mod Wheel
     sendPitchBend = _dylib.lookupFunction<SendPitchBendC, SendPitchBendDart>('send_pitch_bend_ffi');
-    sendModWheel = _dylib.lookupFunction<SendModWheelC, SendModWheelDart>('send_mod_wheel_ffi');
+    sendModWheel = _dylib.lookupFunction<SendModWheelC, SendModWheelDart>('send_mod_wheel_ffi'); // Existing, specific to CC1
+    // Lookup for the new generic sendControlChange function
+    // Assuming the native function is named 'send_control_change_ffi'
+    sendControlChange = _dylib.lookupFunction<SendControlChangeC, SendControlChangeDart>('send_control_change_ffi');
   }
 }

--- a/lib/features/controls/modulation_wheel_widget.dart
+++ b/lib/features/controls/modulation_wheel_widget.dart
@@ -1,0 +1,175 @@
+import 'package:flutter/material.dart';
+import '../../core/ffi/native_audio_ffi.dart'; // FFI
+import '../../ui/holographic/holographic_theme.dart'; // For styling
+
+class ModulationWheelWidget extends StatefulWidget {
+  final Size size;
+  final int ccNumber;
+
+  const ModulationWheelWidget({
+    Key? key,
+    this.size = const Size(60, 150),
+    this.ccNumber = 1, // Default to Modulation CC
+  }) : super(key: key);
+
+  @override
+  _ModulationWheelWidgetState createState() => _ModulationWheelWidgetState();
+}
+
+class _ModulationWheelWidgetState extends State<ModulationWheelWidget> {
+  double _currentValue = 0.0; // 0.0 to 1.0
+  bool _isInteracting = false;
+  final NativeAudioLib _nativeAudioLib = NativeAudioLib();
+
+  @override
+  void initState() {
+    super.initState();
+    // Send initial value if needed, though typical mod wheels start at 0 and send on first move
+    // _sendModulationValue(_currentValue);
+  }
+
+  void _sendModulationValue(double value) {
+    // Convert UI value (0.0 to 1.0) to MIDI CC Value (0 to 127)
+    int midiCCValue = (value * 127).round().clamp(0, 127);
+
+    print("Modulation: CC: ${widget.ccNumber}, UI Value: ${value.toStringAsFixed(3)}, MIDI Value: $midiCCValue");
+    _nativeAudioLib.sendControlChange(widget.ccNumber, midiCCValue);
+  }
+
+  void _handleDragStart(DragStartDetails details) {
+    _isInteracting = true;
+    final RenderBox box = context.findRenderObject() as RenderBox;
+    final Offset localPosition = box.globalToLocal(details.globalPosition);
+    _updateValueFromPosition(localPosition.dy);
+  }
+
+  void _handleDragUpdate(DragUpdateDetails details) {
+    final RenderBox box = context.findRenderObject() as RenderBox;
+    final Offset localPosition = box.globalToLocal(details.globalPosition);
+    _updateValueFromPosition(localPosition.dy);
+  }
+
+  void _updateValueFromPosition(double yPosition) {
+    final double widgetHeight = widget.size.height;
+    // Calculate value: top is 1.0, bottom is 0.0
+    // yPosition is 0 at the top, widgetHeight at the bottom
+    double newValue = 1.0 - (yPosition / widgetHeight);
+    newValue = newValue.clamp(0.0, 1.0);
+
+    if (_currentValue != newValue) {
+      setState(() {
+        _currentValue = newValue;
+      });
+      _sendModulationValue(_currentValue);
+    }
+  }
+
+  void _handleDragEnd(DragEndDetails details) {
+    setState(() {
+      _isInteracting = false;
+    });
+    // No auto-return, but ensure the final value is sent if it hasn't been
+    // _sendModulationValue(_currentValue); // Usually already sent by _updateValueFromPosition
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onVerticalDragStart: _handleDragStart,
+      onVerticalDragUpdate: _handleDragUpdate,
+      onVerticalDragEnd: _handleDragEnd,
+      onVerticalDragCancel: () {
+        setState(() {
+          _isInteracting = false;
+        });
+      },
+      child: Container(
+        width: widget.size.width,
+        height: widget.size.height,
+        decoration: BoxDecoration(
+          color: Colors.grey[800], // Placeholder background
+          borderRadius: BorderRadius.circular(widget.size.width / 2),
+          border: Border.all(color: Colors.grey[600]!, width: 2),
+        ),
+        child: CustomPaint(
+          painter: _ModulationWheelPainter(_currentValue, widget.size.width, _isInteracting),
+          size: widget.size,
+        ),
+      ),
+    );
+  }
+}
+
+// Simple painter for the wheel/slider visual
+class _ModulationWheelPainter extends CustomPainter {
+  final double value; // 0.0 to 1.0
+  final double wheelWidth;
+  final bool isInteracting;
+
+  _ModulationWheelPainter(this.value, this.wheelWidth, this.isInteracting);
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final Paint trackPaint = Paint()
+      ..color = Colors.grey[700]!
+      ..style = PaintingStyle.fill;
+
+    final Paint thumbPaint = Paint()
+      ..color = isInteracting ? HolographicTheme.accentEnergy : HolographicTheme.secondaryEnergy // Different color for interaction
+      ..style = PaintingStyle.fill;
+
+    final double trackWidth = wheelWidth * 0.4;
+    final double trackCenterX = size.width / 2;
+
+    canvas.drawRRect(
+      RRect.fromRectAndRadius(
+        Rect.fromLTWH(trackCenterX - trackWidth / 2, 0, trackWidth, size.height),
+        Radius.circular(trackWidth / 2)
+      ),
+      trackPaint
+    );
+
+    // Thumb position:
+    // value = 1.0 (top) => thumbY = thumbRadius
+    // value = 0.0 (bottom) => thumbY = size.height - thumbRadius
+    final double thumbRadius = wheelWidth * 0.45;
+    final double usableHeight = size.height - 2 * thumbRadius; // Space for thumb to move fully top to bottom
+
+    // Inverse relationship for y: value 0 is bottom, value 1 is top
+    final double thumbY = (size.height - thumbRadius) - (value * usableHeight);
+
+    canvas.drawCircle(Offset(trackCenterX, thumbY.clamp(thumbRadius, size.height - thumbRadius)), thumbRadius, thumbPaint);
+
+    // Optional: Min/Max indicators or a filled track up to the thumb
+    final Paint fillPaint = Paint()
+      ..color = thumbPaint.color.withOpacity(0.3)
+      ..style = PaintingStyle.fill;
+
+    double fillHeight = value * (size.height - 2 * thumbRadius) + thumbRadius;
+    fillHeight = fillHeight.clamp(thumbRadius, size.height - thumbRadius);
+    if (value > 0.01) { // Only draw fill if value is somewhat up
+        canvas.drawRRect(
+        RRect.fromRectAndCorners(
+            Rect.fromLTRB(
+            trackCenterX - trackWidth / 2,
+            size.height - fillHeight, // Start from bottom
+            trackCenterX + trackWidth / 2,
+            size.height - thumbRadius // Go up to bottom of thumb
+            ),
+            bottomLeft: Radius.circular(trackWidth/2),
+            bottomRight: Radius.circular(trackWidth/2),
+        ),
+        fillPaint
+        );
+    }
+
+
+  }
+
+  @override
+  bool shouldRepaint(covariant _ModulationWheelPainter oldDelegate) {
+    return oldDelegate.value != value ||
+           oldDelegate.wheelWidth != wheelWidth ||
+           oldDelegate.isInteracting != isInteracting;
+  }
+}

--- a/lib/features/controls/pitch_bend_wheel_widget.dart
+++ b/lib/features/controls/pitch_bend_wheel_widget.dart
@@ -1,0 +1,198 @@
+import 'package:flutter/material.dart';
+import 'dart:async'; // For Timer, if needed for animation fallback
+import '../../core/ffi/native_audio_ffi.dart'; // FFI
+import '../../ui/holographic/holographic_theme.dart'; // For styling (optional for now)
+
+class PitchBendWheelWidget extends StatefulWidget {
+  final Size size;
+
+  const PitchBendWheelWidget({
+    Key? key,
+    this.size = const Size(60, 150),
+  }) : super(key: key);
+
+  @override
+  _PitchBendWheelWidgetState createState() => _PitchBendWheelWidgetState();
+}
+
+class _PitchBendWheelWidgetState extends State<PitchBendWheelWidget>
+    with SingleTickerProviderStateMixin {
+  double _currentValue = 0.0; // -1.0 to 1.0
+  bool _isInteracting = false;
+  final NativeAudioLib _nativeAudioLib = NativeAudioLib();
+  late AnimationController _returnToCenterController;
+  Animation<double>? _returnAnimation;
+
+  @override
+  void initState() {
+    super.initState();
+    _returnToCenterController = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 200), // Adjust duration as needed
+    )
+      ..addListener(() {
+        if (_isInteracting) return; // Don't update if user is still dragging
+        setState(() {
+          _currentValue = _returnAnimation!.value;
+        });
+        _sendPitchBendValue(_currentValue);
+      })
+      ..addStatusListener((status) {
+        if (status == AnimationStatus.completed) {
+          // Ensure final value is exactly 0.0
+          if (!_isInteracting) { // Check again, user might have re-touched
+            setState(() {
+              _currentValue = 0.0;
+            });
+          }
+          _sendPitchBendValue(0.0);
+        }
+      });
+  }
+
+  void _sendPitchBendValue(double value) {
+    // Convert UI value (-1.0 to 1.0) to MIDI Pitch Bend Value (0 to 16383)
+    // 0.0 on the wheel = center of MIDI range (8192)
+    // 1.0 on the wheel = max MIDI value (16383)
+    // -1.0 on the wheel = min MIDI value (0)
+    int midiPitchBend = ((value + 1.0) / 2.0 * 16383).round().clamp(0, 16383);
+
+    // For now, print. Later, this will call the FFI function.
+    print("Pitch Bend: UI Value: ${value.toStringAsFixed(3)}, MIDI Value: $midiPitchBend");
+    _nativeAudioLib.sendPitchBend(midiPitchBend);
+  }
+
+  void _handleDragStart(DragStartDetails details) {
+    _returnToCenterController.stop(); // Stop any return animation
+    _isInteracting = true;
+    // Calculate initial value based on touch position
+    // This might need adjustment based on how you render the draggable area
+    final RenderBox box = context.findRenderObject() as RenderBox;
+    final Offset localPosition = box.globalToLocal(details.globalPosition);
+    _updateValueFromPosition(localPosition.dy);
+  }
+
+  void _handleDragUpdate(DragUpdateDetails details) {
+    final RenderBox box = context.findRenderObject() as RenderBox;
+    final Offset localPosition = box.globalToLocal(details.globalPosition);
+    _updateValueFromPosition(localPosition.dy);
+  }
+
+  void _updateValueFromPosition(double yPosition) {
+    final double widgetHeight = widget.size.height;
+    // Calculate value: top is 1.0, middle is 0.0, bottom is -1.0
+    // yPosition is 0 at the top, widgetHeight at the bottom
+    double newValue = (widgetHeight / 2 - yPosition) / (widgetHeight / 2);
+    newValue = newValue.clamp(-1.0, 1.0);
+
+    if (_currentValue != newValue) {
+      setState(() {
+        _currentValue = newValue;
+      });
+      _sendPitchBendValue(_currentValue);
+    }
+  }
+
+  void _handleDragEnd(DragEndDetails details) {
+    _isInteracting = false;
+    // Start animation to return to center (0.0)
+    _returnAnimation = Tween<double>(
+      begin: _currentValue,
+      end: 0.0,
+    ).animate(CurvedAnimation(
+      parent: _returnToCenterController,
+      curve: Curves.easeOut, // Or another curve you prefer
+    ));
+    _returnToCenterController.reset();
+    _returnToCenterController.forward();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return GestureDetector(
+      onVerticalDragStart: _handleDragStart,
+      onVerticalDragUpdate: _handleDragUpdate,
+      onVerticalDragEnd: _handleDragEnd,
+      onVerticalDragCancel: () { // Also handle cancel
+        _isInteracting = false;
+        if (!_returnToCenterController.isAnimating) {
+           _handleDragEnd(DragEndDetails()); // Treat cancel like end
+        }
+      },
+      child: Container(
+        width: widget.size.width,
+        height: widget.size.height,
+        decoration: BoxDecoration(
+          color: Colors.grey[800], // Placeholder background
+          borderRadius: BorderRadius.circular(widget.size.width / 2),
+          border: Border.all(color: Colors.grey[600]!, width: 2),
+        ),
+        child: CustomPaint(
+          painter: _PitchBendWheelPainter(_currentValue, widget.size.width),
+          size: widget.size,
+        ),
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _returnToCenterController.dispose();
+    super.dispose();
+  }
+}
+
+// Simple painter for the wheel/slider visual
+class _PitchBendWheelPainter extends CustomPainter {
+  final double value; // -1.0 to 1.0
+  final double wheelWidth;
+
+  _PitchBendWheelPainter(this.value, this.wheelWidth);
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final Paint trackPaint = Paint()
+      ..color = Colors.grey[700]!
+      ..style = PaintingStyle.fill;
+
+    final Paint thumbPaint = Paint()
+      ..color = HolographicTheme.primaryEnergy // Use a theme color
+      ..style = PaintingStyle.fill;
+
+    final double trackWidth = wheelWidth * 0.4;
+    final double trackCenterX = size.width / 2;
+
+    // Draw track (simple line for now)
+    canvas.drawRRect(
+      RRect.fromRectAndRadius(
+        Rect.fromLTWH(trackCenterX - trackWidth / 2, 0, trackWidth, size.height),
+        Radius.circular(trackWidth / 2)
+      ),
+      trackPaint
+    );
+
+    // Thumb position:
+    // value = 1.0 (top) => thumbY = thumbRadius
+    // value = 0.0 (center) => thumbY = size.height / 2
+    // value = -1.0 (bottom) => thumbY = size.height - thumbRadius
+    final double thumbRadius = wheelWidth * 0.45; // Thumb is slightly wider than track
+    final double usableHeight = size.height - 2 * thumbRadius;
+    final double thumbY = (size.height / 2) - (value * usableHeight / 2);
+
+    canvas.drawCircle(Offset(trackCenterX, thumbY.clamp(thumbRadius, size.height - thumbRadius)), thumbRadius, thumbPaint);
+
+    // Center line indicator
+    final Paint centerLinePaint = Paint()
+      ..color = Colors.black.withOpacity(0.5)
+      ..strokeWidth = 1.0;
+    canvas.drawLine(
+        Offset(trackCenterX - thumbRadius, size.height / 2),
+        Offset(trackCenterX + thumbRadius, size.height / 2),
+        centerLinePaint);
+  }
+
+  @override
+  bool shouldRepaint(covariant _PitchBendWheelPainter oldDelegate) {
+    return oldDelegate.value != value || oldDelegate.wheelWidth != wheelWidth;
+  }
+}


### PR DESCRIPTION
This commit introduces new interactive performance controls:

1.  **Polyphonic Aftertouch for Virtual Keyboard:** The `VirtualKeyboardWidget` now supports polyphonic aftertouch. It detects continuous pressure on individual keys and sends corresponding MIDI polyphonic aftertouch messages (0-127) via `NativeAudioLib.sendPolyAftertouch(note, pressure)`. Initial pressure is sent on note-on, and pressure is reset to 0 on note-off. This allows for more expressive playing.

2.  **On-Screen Pitch Bend Wheel:** Added `PitchBendWheelWidget`, a UI component that simulates a pitch bend wheel. It translates vertical drag (-1.0 to 1.0) into 14-bit MIDI pitch bend messages (0-16383) sent via `NativeAudioLib.sendPitchBend(value)`. The wheel automatically returns to the center (8192) upon release.

3.  **On-Screen Modulation Wheel:** Added `ModulationWheelWidget`, a UI component for MIDI CC control. It translates vertical drag (0.0 to 1.0) into 7-bit MIDI CC messages (0-127) for a configurable CC number (defaulting to 1 for modulation). It sends messages via `NativeAudioLib.sendControlChange(cc, value)` and does not auto-return.

4.  **FFI and Documentation:** Added FFI function bindings in `native_audio_ffi.dart` for `sendPitchBend` and `sendControlChange`. Updated `API_REFERENCE.md` and `README.md` to reflect these new features and their usage.