### PR TITLE
fix: Resolve layout overlapping and set default collapsed states

### DIFF
--- a/lib/ui/professional_synthesizer_interface.dart
+++ b/lib/ui/professional_synthesizer_interface.dart
@@ -40,14 +40,14 @@ class _ProfessionalSynthesizerInterfaceState extends State<ProfessionalSynthesiz
   
   // Section visibility and collapse states
   final Map<String, bool> _sectionCollapsed = {
-    'oscillators': false,
-    'filters': false,
-    'envelopes': false,
-    'lfos': false,
-    'effects': false,
-    'modulation': false,
-    'spectrum': false,
-    'master': false,
+    'oscillators': false, // Start open
+    'filters': false,     // Start open
+    'envelopes': true,    // Start collapsed
+    'lfos': true,         // Start collapsed
+    'effects': true,      // Start collapsed
+    'modulation': true,   // Start collapsed
+    'spectrum': false,    // Keep open by default (or true if it should be initially hidden)
+    'master': false,      // Master section in header, usually not collapsed
   };
 
   @override
@@ -133,10 +133,12 @@ class _ProfessionalSynthesizerInterfaceState extends State<ProfessionalSynthesiz
             _buildHolographicBackground(),
             
             // Main synthesizer interface with error handling
-            _buildSynthesizerLayoutSafe(),
+            Positioned.fill( // Wrap with Positioned.fill
+              child: _buildSynthesizerLayoutSafe(),
+            ),
             
             // Floating spectrum analyzer overlay
-            _buildFloatingSpectrumAnalyzer(),
+            _buildFloatingSpectrumAnalyzer(), // This is already Positioned
             
             // Chromatic aberration overlay
             _buildChromaticAberrationOverlay(),


### PR DESCRIPTION
This commit addresses two main issues:
1.  **Overlapping Sections Layout:** Widgets in the main synthesizer interface were reported to be overlapping instead of laying out sequentially. This was likely due to the main `SingleChildScrollView` not properly expanding within its parent `Stack`. The `_buildSynthesizerLayoutSafe()` widget in `professional_synthesizer_interface.dart` has been wrapped with `Positioned.fill()` to ensure it correctly occupies the available space within the root `Stack`. This should allow the internal `Column` to lay out sections vertically as intended.

2.  **Default Collapsed States:** To improve initial UI clarity and manage screen space, default collapsed states for sections have been implemented. The `_sectionCollapsed` map in `professional_synthesizer_interface.dart` has been updated to start the following sections as collapsed:
    - Envelopes
    - LFOs
    - Effects
    - Modulation Matrix Oscillators and Filters will remain open by default.