### PR TITLE
feat: Temporarily neutralize section transforms for layout diagnostics

### DIFF
--- a/lib/ui/professional_synthesizer_interface.dart
+++ b/lib/ui/professional_synthesizer_interface.dart
@@ -101,16 +101,8 @@ class _ProfessionalSynthesizerInterfaceState extends State<ProfessionalSynthesiz
     final sections = _sectionTransforms.keys;
     for (int i = 0; i < sections.length; i++) {
       final section = sections.elementAt(i);
-      final matrix = vector.Matrix4.identity();
-      
-      // Apply 4D rotation based on pulse and section index
-      final rotationW = pulse * 2 * 3.14159 + (i * 0.5);
-      final rotationY = pulse * 1.5 * 3.14159 + (i * 0.3);
-      
-      matrix.rotateY(rotationY * 0.1);
-      matrix.translate(0.0, Math.sin(rotationW) * 2.0, Math.cos(rotationW) * 1.0);
-      
-      _sectionTransforms[section] = matrix;
+      // For diagnostics: Set to identity matrix to remove custom transforms
+      _sectionTransforms[section] = vector.Matrix4.identity();
     }
   }
 


### PR DESCRIPTION
This commit modifies the `_updateSectionTransforms` method in `professional_synthesizer_interface.dart` to set all per-section transformation matrices to `Matrix4.identity()`.

This change is intended for diagnostic purposes to determine if the custom 4D transformations (rotations and translations) applied to each synthesizer section were the cause of the reported layout issue where sections were overlapping instead of appearing sequentially.

By neutralizing these transforms, if the layout now appears correctly (i.e., sections are in a proper column/row flow), it will indicate that the way these transforms were applied was interfering with the Flutter layout system. If the overlap persists, the root cause lies elsewhere in the widget hierarchy or sizing logic.